### PR TITLE
Updated documentation and example script to reflect fixed kerchunk bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,16 +161,14 @@ a shared collection of metadata.
 #### Kerchunk (daily and hourly data)
 
 We support kerchunk virutal zarr access for both hourly and daily
-data via the parquet directories at
-`s3://nasa-waterinsight/virtual/nldas3_daily.parq` and
-`s3://nasa-waterinsight/virtual/nldas3_hourly.parq`, respectively,
-as demonstrated below.
+data via the following parquet directories:
 
-**BEWARE**: the time dimension for daily kerchunk data is
-fictitiously offset by one day, so Jan 1, 2012 appears as Jan 2, 2012
-in the virtual Dataset object. This issue does not affect the hourly
-kerchunk data or the daily icechunk method, and will be resolved in
-subsequent versions of the forcing data.
+- `s3://nasa-waterinsight/virtual/nldas3_daily.parq`
+- `s3://nasa-waterinsight/virtual/nldas3_hourly.parq`
+
+The code block below shows the basic pattern for declaring a virtual
+dataset. For a more complete demonstration including a method for
+creating hourly animations, see [this script][17].
 
 ```python
 import fsspec
@@ -194,15 +192,13 @@ ds = xr.open_zarr(
         )
 ```
 
-For a more complete demonstration including a method for creating
-hourly animations, see [this script][17].
-
 #### Icechunk (daily data only)
 
 Currently, only daily data is accessible using the icechunk method
-via the repo at `virtual-zarr-store/NLDAS-3-icechunk`. This approach
-isn't affected by the off-by-one error described under the Kerchunk
-section, and may be slightly more efficient.
+via the repo at `virtual-zarr-store/NLDAS-3-icechunk`. After
+declaring the virtual dataset this method is practically the same
+as the kerchunk approach, but may be slightly more efficient for
+some access patterns.
 
 ```python
 import icechunk

--- a/scripts/read_nldas3_kerchunk_from_refs.py
+++ b/scripts/read_nldas3_kerchunk_from_refs.py
@@ -92,6 +92,7 @@ def animate_geo_raster(data, lats, lons, times=None, plot_spec={}):
     return ani
 
 if __name__=="__main__":
+    repo_root = Path("/Users/mtdodson/Desktop/projects/NLDAS-3")
     ## hurricane sandy landfall in maryland
     time_slice = slice("2012-10-28", "2012-10-30")
     lon_slice = slice(-78.5,-73.5)
@@ -102,8 +103,8 @@ if __name__=="__main__":
     animate = True
     animation_dpi = 80
 
-    buffer_npz_path = Path("test_nldas3_hourly.npz")
-    out_animation_path = Path("test_nldas3_hourly.gif")
+    buffer_npz_path = repo_root.joinpath("tmp/data/test_nldas3_hourly.npz")
+    out_animation_path = repo_root.joinpath("tmp/figures/test_nldas3_hourly.gif")
 
     if download_new:
         ## Set up a reference file system based on the chunk refs stored in


### PR DESCRIPTION
Previously, kerchunk refs were affected by a metadata errors that caused data values equal to zero to be decoded as Nan, and daily data had an erroneous forward offset by one day caused by the source file attribute data.

Both of these issues have been fixed in the parquet files on the s3 bucket, so updating the documentation to reflect.